### PR TITLE
Fix aither, blutopia and haidan

### DIFF
--- a/ptsites/trackers/aither.py
+++ b/ptsites/trackers/aither.py
@@ -1,4 +1,5 @@
 from typing import Final
+import re
 
 from ..base.entry import SignInEntry
 from ..base.sign_in import check_final_state, SignState
@@ -36,9 +37,9 @@ class MainClass(Unit3D):
                     'do_not_strip': True,
                     'elements': {
                         'bar': 'ul.top-nav__ratio-bar',
-                        'registration_date': 'article > time',
-                        'warnings': 'article > aside > section:nth-child(2)',
-                        'data_table': 'article > aside > section:nth-child(4)'
+                        'registration_date': 'main',
+                        'warnings': 'main',
+                        'data_table': 'main'
                     }
                 }
             },
@@ -52,7 +53,8 @@ class MainClass(Unit3D):
                     'handle': self.remove_symbol
                 },
                 'points': {
-                    'regex': r'title="My bonus points".*?</i>.*?(\d[\d,. ]*)',
+                    'regex': r'title="My bonus points".*?</i>.*?(\d[\d,. \u202f]*)',
+                    'handle': self.remove_symbol
                 },
                 'share_ratio': {
                     'regex': 'title="Ratio".*?</i>.+?(\\d[\\d,. ]*)',
@@ -61,12 +63,11 @@ class MainClass(Unit3D):
                     'regex': r'Registration date.*?(\d{4}-\d{2}-\d{2})',
                     'handle': handle_join_date
                 },
-                'hr': {
-                    'regex': r'Hit and run count.*?(\d+)'
-                }
+                'hr': None
             }
         })
         return selector
 
     def remove_symbol(self, value: str):
-        return value.replace('\xa0', '')
+        # Strip regular spaces, no-break space (\xa0) and narrow no-break space (\u202f)
+        return re.sub(r'[\s\xa0\u202f]', '', value)

--- a/ptsites/trackers/blutopia.py
+++ b/ptsites/trackers/blutopia.py
@@ -1,3 +1,4 @@
+import re
 from typing import Final
 
 from ..base.entry import SignInEntry
@@ -44,15 +45,19 @@ class MainClass(Unit3D):
             'details': {
                 'uploaded': {
                     'regex': r'title="Upload".*?</i>.+?([\d.]+.*?[ZEPTGMK]?iB)',
+                    'handle': self.handle_whitespace
                 },
                 'downloaded': {
                     'regex': r'title="Download".*?</i>.+?([\d.]+.*?[ZEPTGMK]?iB)',
+                    'handle': self.handle_whitespace
                 },
                 'points': {
-                    'regex': 'title="Bonus points".*?</i>.+?(\\d[\\d,. ]*)',
+                    'regex': 'title="Bonus points".*?</i>.+?(\\d[\\d,.\u202f\u00a0 ]*)',
+                    'handle': self.handle_number
                 },
                 'share_ratio': {
-                    'regex': 'title="Ratio".*?</i>.+?(\\d[\\d,. ]*)',
+                    'regex': 'title="Ratio".*?</i>.+?(\\d[\\d,.\u202f\u00a0 ]*)',
+                    'handle': self.handle_number
                 },
                 'join_date': {
                     'regex': r'Registration date:.*?(\d{4}-\d{2}-\d{2})',
@@ -64,3 +69,12 @@ class MainClass(Unit3D):
             }
         })
         return selector
+
+    def handle_number(self, value: str) -> str:
+        # The site uses U+202F or U+00A0 as the thousands separator, which the
+        # plain space class does not match. Strip them; commas are handled downstream.
+        return re.sub(r'[\u202f\u00a0\s]', '', value)
+
+    def handle_whitespace(self, value: str) -> str:
+        # The gap between value and unit may be \xa0 (&nbsp;); normalise to a plain space
+        return re.sub(r'\s+', ' ', value)

--- a/ptsites/trackers/haidan.py
+++ b/ptsites/trackers/haidan.py
@@ -8,7 +8,7 @@ from ..utils import net_utils
 
 
 class MainClass(NexusPHP, ReseedPasskey):
-    URL: Final = 'https://www.haidan.video/'
+    URL: Final = 'https://www.haidan.cc/'
     USER_CLASSES: Final = {
         'downloaded': [2199023255552, 8796093022208],
         'share_ratio': [4, 5.5],


### PR DESCRIPTION
Three site adaptation fixes, tested against live accounts.

**haidan** — the site moved from haidan.video to haidan.cc.

**aither** — the profile page layout changed and the old child selectors
(`article > time`, `article > aside > section:nth-child(2)`) no longer
match, so they are relaxed to `main`. The site also switched to U+202F
(narrow no-break space) as a thousands separator for bonus points, which
the previous regex did not cover — `remove_symbol` now strips it as well.
Hit and run is no longer shown on the profile, so `hr` is set to `None`
rather than matching an unrelated number.

**blutopia** — same U+202F/U+00A0 thousands separator issue on bonus
points and ratio, plus non-breaking spaces between the value and its unit
for upload/download.