### PR TITLE
Fix crash when a site reports no join_date

### DIFF
--- a/ptsites/utils/details_report.py
+++ b/ptsites/utils/details_report.py
@@ -178,10 +178,11 @@ class DetailsReport:
 
             # update db
             for key, value in details_now.items():
+                if value == '*':
+                    continue
                 if key == 'join_date':
                     value = parse(value)
-                if value != '*':
-                    setattr(user_details_db, key, value)
+                setattr(user_details_db, key, value)
             session.commit()
 
         data['site'].append('total')


### PR DESCRIPTION
When a site sets `details['join_date'] = None`, the value is rendered as
the `'*'` placeholder. In `DetailsReport.build()` the placeholder check
runs *after* `parse()`, so dateutil raises
`ParserError: Unknown string format: *` and the whole task aborts:

File "ptsites/utils/details_report.py", line 182, in build
value = parse(value)
dateutil.parser._parser.ParserError: Unknown string format: *


The `'*'` check already exists on the next line — it just runs too late.
Moving it first makes the code behave as apparently intended, and matches
how the `hr` field already tolerates `'*'`.

This affects hdsky, which sets `details['join_date'] = None` — any user
who omits `join_date` from their config hits the crash.