### PR TITLE
myanonamouse: sign in with a session cookie instead of a password

### DIFF
--- a/ptsites/trackers/myanonamouse.py
+++ b/ptsites/trackers/myanonamouse.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
-import re
 from typing import Final
 
-from requests import Response
-
 from ..base.entry import SignInEntry
-from ..base.request import check_network_state, NetworkState
-from ..base.sign_in import check_final_state, SignState, Work
+from ..base.sign_in import check_final_state, SignState
+from ..base.work import Work
 from ..schema.private_torrent import PrivateTorrent
 from ..utils.net_utils import get_module_name
-from ..utils.value_handler import handle_join_date, handle_infinite
+from ..utils.value_handler import handle_infinite
 
 
 class MainClass(PrivateTorrent):
@@ -27,14 +24,8 @@ class MainClass(PrivateTorrent):
             get_module_name(cls): {
                 'type': 'object',
                 'properties': {
-                    'login': {
-                        'type': 'object',
-                        'properties': {
-                            'username': {'type': 'string'},
-                            'password': {'type': 'string'}
-                        },
-                        'additionalProperties': False
-                    }
+                    'cookie': {'type': 'string'},
+                    'join_date': {'type': 'string', 'format': 'date'}
                 },
                 'additionalProperties': False
             }
@@ -43,81 +34,46 @@ class MainClass(PrivateTorrent):
     def sign_in_build_workflow(self, entry: SignInEntry, config: dict) -> list[Work]:
         return [
             Work(
-                url='/login.php',
+                url='/jsonLoad.php?snatch_summary',
                 method=self.sign_in_by_get,
-                assert_state=(check_network_state, NetworkState.SUCCEED),
-            ),
-            Work(
-                url='/takelogin.php',
-                method=self.sign_in_by_login,
-                succeed_regex=['Log Out'],
-                response_urls=['/u/'],
+                succeed_regex=[r'"uid":\s*\d+'],
+                response_urls=['/jsonLoad.php?snatch_summary'],
                 assert_state=(check_final_state, SignState.SUCCEED),
                 is_base_content=True,
-                t_regex='<input type="hidden" name="t" value="([^"]+)"',
-                a_regex='<input type="hidden" name="a" value="([^"]+)"',
             )
         ]
-
-    def sign_in_by_login(self, entry: SignInEntry, config: dict, work: Work, last_content: str) -> Response | None:
-        if not (login := entry['site_config'].get('login')):
-            entry.fail_with_prefix('Login data not found!')
-            return None
-
-        t = re.search(work.t_regex, last_content).group(1)
-        j = str(len(t))
-        a = re.search(work.a_regex, last_content).group(1)
-
-        # 修改：使用普通字典而不是元组格式
-        data = {
-            't': t,
-            'j': j,
-            'a': a,
-            'email': login['username'],
-            'password': login['password'],
-            'rememberMe': 'yes'
-        }
-
-        response = self.request(entry, 'post', work.url, data=data)
-        return response
 
     @property
     def details_selector(self) -> dict:
         return {
-            'user_id': '/u/(\\d+)',
+            'user_id': r'"uid":\s*(\d+)',
             'detail_sources': {
                 'default': {
-                    'link': '/u/{}',
-                    'elements': {
-                        'bar': '.mmUserStats ul',
-                        'table': 'table.coltable'
-                    }
+                    'link': '/jsonLoad.php?snatch_summary',
+                    'elements': None,
                 }
             },
             'details': {
                 'uploaded': {
-                    'regex': r'Uploaded\s+([\d.,]+ [ZEPTGMK]i?B)'
+                    'regex': r'"uploaded":\s*"([\d.,]+ [ZEPTGMK]i?B)"'
                 },
                 'downloaded': {
-                    'regex': r'Downloaded\s+([\d.,]+ [ZEPTGMK]i?B)'
+                    'regex': r'"downloaded":\s*"([\d.,]+ [ZEPTGMK]i?B)"'
                 },
                 'share_ratio': {
-                    'regex': r'Share\s*ratio\s*?(∞|[\d,.]+)',
+                    'regex': r'"ratio":\s*([\d.]+)',
                     'handle': handle_infinite
                 },
                 'points': {
-                    'regex': r'Bonus:\s+([\d,.]+)'
-                },
-                'join_date': {
-                    'regex': r'Join\s+date\s+(\d{4}-\d{2}-\d{2})',
-                    'handle': handle_join_date
+                    'regex': r'"seedbonus":\s*([\d.]+)'
                 },
                 'seeding': {
-                    'regex': r'(\d+)\s+seeding\s+unsatisfied\s+torrents'
+                    'regex': r'"seedUnsat":\s*\{\s*"count":\s*(\d+)'
                 },
                 'leeching': {
-                    'regex': r'(\d+)\s+leeching\s+torrents'
+                    'regex': r'"leeching":\s*\{\s*"count":\s*(\d+)'
                 },
-                'hr': None
+                'join_date': None,
+                'hr': None,
             }
         }


### PR DESCRIPTION
The current module posts username/password to `/takelogin.php` on every
run. MyAnonaMouse counts login attempts, and repeated automated logins
eventually trigger a "Login Locked!" lockout on the account — the site is
explicitly unfriendly to scripted password logins.

MAM provides session cookies (`mam_id`) for exactly this purpose, created
under Preferences → Security and lockable to an IP or an ASN. This
switches the module to cookie auth and reads stats from
`/jsonLoad.php?snatch_summary`.

An API session cannot access HTML pages, so the join date is supplied
through config instead, following the same pattern hdsky already uses:

```yaml
myanonamouse:
  cookie: 'mam_id=...'
  join_date: '2021-11-19'
```

Depends on #185 — without it, omitting `join_date` crashes the task.

Tested against a live account: uploaded, downloaded, share_ratio, points,
seeding and leeching all populate correctly, and user class detection
works with the configured join date.